### PR TITLE
Screenshot scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,28 @@ class MyTest {
     // ...
 }
 ```
+`FailshotRule` can be customized to limit size and/or quality of screenshots.
+
+Scale screenshot down to half of original size, 90% quality:
+```kotlin
+class MyTest {
+
+    @get:Rule
+    val failshot = (scale = 0.5f, quality = 70)
+
+    // ...
+}
+```
+Set maximum screenshot width to 600 px:
+```kotlin
+class MyTest {
+
+    @get:Rule
+    val failshot = (maxWidth = 600) // will scale screenshot down to half of original size
+
+    // ...
+}
+```
 
 ### Logcat rule's (only in new version)
 You can use `LogcatDumpRule`, `LogcatClearRule` to clear and capture a device logs in case of `Throwable` during test

--- a/allure-espresso/src/androidTest/kotlin/io/qameta/allure/android/AllureTest.kt
+++ b/allure-espresso/src/androidTest/kotlin/io/qameta/allure/android/AllureTest.kt
@@ -1,15 +1,23 @@
 package io.qameta.allure.android
 
+
 import androidx.test.runner.AndroidJUnit4
+import io.qameta.allure.android.annotations.DisplayName
+import io.qameta.allure.android.annotations.Epic
+import io.qameta.allure.android.annotations.Features
+import io.qameta.allure.android.annotations.Feature
+import io.qameta.allure.android.annotations.Issue
+import io.qameta.allure.android.annotations.Stories
+import io.qameta.allure.android.annotations.Story
+import io.qameta.allure.android.annotations.TmsLink
+import io.qameta.allure.android.annotations.Severity
+import io.qameta.allure.android.annotations.Tags
+import io.qameta.allure.android.annotations.Tag
+import io.qameta.allure.android.annotations.Owner
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
-import io.qameta.allure.android.annotations.DisplayName
-import io.qameta.allure.android.annotations.Issue
-import io.qameta.allure.android.annotations.Owner
-import io.qameta.allure.android.annotations.Severity
-import io.qameta.allure.android.annotations.TmsLink
 import io.qameta.allure.espresso.FailshotRule
 import io.qameta.allure.espresso.LogcatClearRule
 import io.qameta.allure.espresso.LogcatDumpRule
@@ -26,11 +34,26 @@ import kotlin.test.fail
 @RunWith(AndroidJUnit4::class)
 @Issue("ISSUE-123")
 @DisplayName("allure-android")
+@Epic("Epic-1")
+@Features(
+        Feature("Feature-1"),
+        Feature("Feature-2")
+)
+@Stories(
+        Story("Story-1"),
+        Story("Story-2")
+)
+@Tags(
+        Tag("Tag-1"),
+        Tag("Tag-1")
+)
 class AllureTest {
 
     @get:Rule
-    val ruleChain = RuleChain.outerRule(LogcatClearRule()).around(FailshotRule())
-            .around(WindowHierarchyRule()).around(LogcatDumpRule())
+    val ruleChain = RuleChain.outerRule(LogcatClearRule())
+            .around(FailshotRule())
+            .around(WindowHierarchyRule())
+            .around(LogcatDumpRule())
 
     @Test
     fun shouldAddGreenStep() = step("Step1") {

--- a/allure-espresso/src/main/kotlin/io/qameta/allure/espresso/FailshotRule.kt
+++ b/allure-espresso/src/main/kotlin/io/qameta/allure/espresso/FailshotRule.kt
@@ -5,10 +5,35 @@ import org.junit.runner.Description
 import org.junit.runners.model.Statement
 
 /**
- * @author Badya on 25.05.2017.
+ * JUnit Rule to take current window screenshot and add it to Allure test result as attachment in case of failures.
+ *
+ * Usage examples:
+ * 1. Default - Screenshot will not scale, image quality by default is 90%
+ *
+ *  @get:Rule
+ *  val failshot = FailshotRule()
+ *
+ * 2. Scale image by defining width in pixels
+ *  @get:Rule
+ *  val failshot = FailshotRule(maxWidth = 600, quality = 90)
+ *
+ * 3. Scale image by %. If 0.5f is defined, resulting screenshot size will be half of original
+ *  @get:Rule
+ *  val failshot = FailshotRule(scale = 0.5f, quality = 90)
+ *
+ * 4. Only reduce quality (screenshot will be saved with 20% quality)
+ *  @get:Rule
+ *  val failshot = FailshotRule(quality = 20)
+ *
+ * @param maxWidth max screenshot width in pixels (ignored if less than actual width)
+ * @param scale scale the screenshot down if needed; 1.0f for original size (ignored if maxWidth defined)
+ * @param quality quality of screenshot image, 1-100, by default set to 90
  */
-@Suppress("unused")
-class FailshotRule : TestRule {
+@Suppress("unused", "MemberVisibilityCanBePrivate")
+class FailshotRule(val maxWidth: Int? = null,
+                   val scale: Float? = null,
+                   val quality: Int? = null) : TestRule {
+
     override fun apply(base: Statement, description: Description): Statement {
         return object : Statement() {
             override fun evaluate() {
@@ -23,6 +48,6 @@ class FailshotRule : TestRule {
     }
 
     private fun failshot() {
-        deviceScreenshot("failshot")
+        deviceScreenshot(tag = "failshot", scale = scale, maxWidth = maxWidth, quality = quality)
     }
 }

--- a/allure-espresso/src/main/kotlin/io/qameta/allure/espresso/Screenshot.kt
+++ b/allure-espresso/src/main/kotlin/io/qameta/allure/espresso/Screenshot.kt
@@ -1,20 +1,109 @@
 package io.qameta.allure.espresso
 
+import android.graphics.Bitmap
+import android.util.Log
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
+import androidx.test.uiautomator.Tracer
 import androidx.test.uiautomator.UiDevice
 import io.qameta.allure.android.io.IMAGE_PNG
 import io.qameta.allure.android.io.PNG_EXTENSION
 import io.qameta.allure.espresso.utils.createAttachmentFile
+import java.io.BufferedOutputStream
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
 import java.util.concurrent.TimeUnit
 
 /**
- * @author Badya on 31.05.2017.
+ * Take a screenshot of current window and add it to current test result as attachment
+ *
+ * @param maxWidth max screenshot width in pixels (ignored if less than actual width)
+ * @param scale scale the screenshot down if needed; 1.0f for original size (ignored if maxWidth defined)
+ * @param quality quality of screenshot image, 1-100, by default set to 90
  */
-fun deviceScreenshot(tag: String) {
+fun deviceScreenshot(tag: String,
+                     scale: Float? = null,
+                     maxWidth: Int? = null,
+                     quality: Int? = null) {
+
+    var screenshotTaken: Boolean
     val file = createAttachmentFile()
     with(UiDevice.getInstance(getInstrumentation())) {
         waitForIdle(TimeUnit.SECONDS.toMillis(5))
-        takeScreenshot(file)
+        screenshotTaken = takeScreenshot(file, scale, maxWidth, quality)
     }
-    AllureAndroidLifecycle.addAttachment(name = tag, type = IMAGE_PNG, fileExtension = PNG_EXTENSION, file = file)
+
+    if (screenshotTaken) {
+        AllureAndroidLifecycle.addAttachment(name = tag, type = IMAGE_PNG, fileExtension = PNG_EXTENSION, file = file)
+    }
+}
+
+/**
+ * Take a screenshot of current window and store it as PNG
+ * (Fixed version of android.support.test.uiautomator.UiDevice#takeScreenshot)
+ *  Screenshot scaling does not work in UI Automator, scale param is not handled properly, had to make local fix.
+ *
+ * The screenshot is adjusted per screen rotation
+ *
+ * @param storePath where the PNG should be written to
+ * @param maxWidth max screenshot width in pixels (ignored if less than actual width)
+ * @param scale scale the screenshot down if needed; 1.0f for original size (ignored if maxWidth defined)
+ * @param quality quality of the PNG compression; range: 0-100 (90 by default)
+ * @return true if screenshot is created successfully, false otherwise
+ * @since API Level 17
+ */
+private fun takeScreenshot(storePath: File,
+                           scale: Float? = null,
+                           maxWidth: Int? = null,
+                           quality: Int? = null): Boolean {
+
+    Tracer.trace(storePath, scale, quality)
+    var screenshot: Bitmap = getInstrumentation().uiAutomation.takeScreenshot()  // requires API level 18
+            ?: return false
+    var bos: BufferedOutputStream? = null
+    try {
+        maxWidth?.let {
+            screenshot = scaleByMaxWidth(screenshot, maxWidth)
+        } ?: scale?.let {
+            // only scale by scaling factor if max width is not defined
+            screenshot = scaleByScalingFactor(screenshot, scale)
+        }
+
+        bos = BufferedOutputStream(FileOutputStream(storePath))
+        screenshot.compress(Bitmap.CompressFormat.PNG, quality ?: 90, bos)
+
+        bos.flush()
+    } catch (ioe: IOException) {
+        Log.e("AllureUtil", "failed to save screenshot to file", ioe)
+        return false
+    } finally {
+        if (bos != null) {
+            try {
+                bos.close()
+            } catch (ioe: IOException) {
+                // Ignore
+            }
+        }
+        screenshot.recycle()
+    }
+    return true
+}
+
+private fun scaleByScalingFactor(screenshot: Bitmap, scale: Float): Bitmap {
+    val originalWidth = screenshot.width
+    val originalHeight = screenshot.height
+    val scaledWidth = (originalWidth * scale).toInt()
+    val scaledHeight = (originalHeight * scale).toInt()
+    return Bitmap.createScaledBitmap(screenshot, scaledWidth, scaledHeight, true)
+}
+
+private fun scaleByMaxWidth(screenshot: Bitmap, maxWidth: Int): Bitmap {
+    val originalWidth = screenshot.width
+    val originalHeight = screenshot.height
+    if (originalWidth < maxWidth) {
+        return screenshot
+    }
+    val scalingFactor = (maxWidth.toFloat() / screenshot.width)
+    val scaledHeight = (originalHeight * scalingFactor).toInt()
+    return Bitmap.createScaledBitmap(screenshot, maxWidth, scaledHeight, true)
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ ext {
     gradleScriptDir = "${rootProject.projectDir}/gradle"
 
     compileSdkVersion = 29
-    minSdkVersion = 15
+    minSdkVersion = 18
     buildToolsVersion = '28.0.3'
 
     gsonVersion = '2.8.0'


### PR DESCRIPTION
As per request in: https://github.com/allure-framework/allure-android/issues/40
Adding FailshotRule option to define screenshots size/quality.

Changes summary:
- Default behavior for FailshotRule() stays same.
- If maxWidth is defined, screenshot will be resized to defined width in pixels.
- If scale is defined, screenshot will be rescaled to defined % of original size.
- if both maxWidth and scale are defined, scale will be ignored.
- If quality is defined, screenshot will be saved with defined quality. Default - 90%. Practice shows that it more or less safe to reduce it to 60% without significant quality losses.

Side effect:
- Had to up min sdk version to 18 (Android 4.3 or later)

In local testing did not notice any performance impact, while images with adjusted quality/size consume way less space on Allure Server. Positive side - can keep way more launches before clean up. 